### PR TITLE
add compatibility with .js configs and search in user folder

### DIFF
--- a/lib/find-eslint-config.js
+++ b/lib/find-eslint-config.js
@@ -1,12 +1,18 @@
 var path = require('path')
 var fs = require('fs')
+var os = require('os')
 var glob = require('glob')
+var requireFromString = require('require-from-string')
 
 module.exports = function findESLintConfig (currFileInfo) {
   var files = glob.sync(path.join(currFileInfo.dir, '.eslintrc*'))
   if (files.length) {
     try {
-      return JSON.parse(fs.readFileSync(files[0], 'utf8'))
+      var fileFound = files[0];
+      var fileContents = fs.readFileSync(fileFound, 'utf8')
+      return fileFound.substring(fileFound.length - 3, fileFound.length) === '.js'
+        ? requireFromString(fileContents)
+        : JSON.parse(fileContents)
     } catch (e) {
       return {}
     }
@@ -14,6 +20,11 @@ module.exports = function findESLintConfig (currFileInfo) {
   if (currFileInfo.dir !== currFileInfo.root) {
     currFileInfo.dir = path.resolve(currFileInfo.dir, '..')
     return findESLintConfig(currFileInfo)
+  }
+  if (currFileInfo.dir !== os.homedir()) {
+    return findESLintConfig({
+        dir: os.homedir()
+    })
   }
   return {}
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "glob": "^7.0.3",
-    "ramda": "^0.21.0"
+    "ramda": "^0.21.0",
+    "require-from-string": "^2.0.2"
   },
   "consumedServices": {
     "status-bar": {


### PR DESCRIPTION
Noticed my Atom stopped benefiting from this package a long time ago, but only for some of my projects.
Realised just now (thanks lockdown-induced spare time), it is due to my having turned some of the config files into `.js`

This little change should handle those, as well as seek the config at the user's home folder (as a last resort, in case the project is not hosted anywhere inside the user's own tree.)